### PR TITLE
Add missing Gradle wrapper properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Added missing Gradle wrapper properties for improved build reliability
- Added networkTimeout and validateDistributionUrl properties
- Ensures consistent build behavior across different environments

## Test plan
- Verify Gradle wrapper works correctly with new properties
- Test build process with network timeout configuration
- Ensure distribution URL validation works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)